### PR TITLE
[BUGFIX] Fixed module not working on adminurl's other than 'storemana…

### DIFF
--- a/view/adminhtml/web/js/action/locale.js
+++ b/view/adminhtml/web/js/action/locale.js
@@ -10,7 +10,13 @@ define(
 
         return function (deferred, localeCode) {
             var param = 'ajax=1';
-            var url = urlBuilder.build("/experius_missingtranslations/ajax/phrases/locale/"+localeCode);
+
+            var extendedUrl = window.location.href;
+            var urlString = extendedUrl.split("experius_missingtranslations")[0];
+            var adminArray = urlString.split("/");
+            var adminUrl = "/" + adminArray[adminArray.length-2];
+            var url = urlBuilder.build(adminUrl + "/experius_missingtranslations/ajax/phrases/locale/" + localeCode);
+
             $.ajax({
                 showLoader: true,
                 url: url,


### PR DESCRIPTION
Bij omgevingen met een adminurl anders dan 'storemanager' verschijnt er een error bij het proberen toevoegen van een nieuwe translation. Dit komt door een 404 in de ajax request in locale.js, omdat de url naar de request niet klopt. Deze fix haalt de adminurl uit de window om een correcte url te maken.

-Rens