### PR TITLE
Make sure JS translations keep working after import

### DIFF
--- a/Model/TranslationCollector.php
+++ b/Model/TranslationCollector.php
@@ -87,6 +87,8 @@ class TranslationCollector
         $translations = array_diff_key($translations, $databaseTranslations);
 
         $insertionCount = $this->createNewTranslations($translations, $storeId, $locale);
+        
+        $this->helper->updateJsTranslationJsonFiles($locale);
 
         $this->emulation->stopEnvironmentEmulation();
         return $insertionCount;


### PR DESCRIPTION
Previously we found out that after importing the new translations the JSON file that is used for Javascript translations was reverted to the default language.

To prevent this we now generate the translation file again for the specific locale after importing.