### PR TITLE
[BUGFIX][HELV-93] Cast community translations to strings

### DIFF
--- a/Model/TranslationCollector.php
+++ b/Model/TranslationCollector.php
@@ -120,6 +120,12 @@ class TranslationCollector
         $insertionCount = 0;
         foreach ($translations as $originalString => $translate) {
             /**
+             * Explicitly cast to string since community engineering translations can contain phrases
+             * that Magento parsing returns as integer
+             */
+            $originalString = (string) $originalString;
+            $translate = (string) $translate;
+            /**
              * Due to Magento table limitation strings longer than 255 characters
              * are being cut off, so these are excluded for now
              */


### PR DESCRIPTION
Cast community translations to strings to prevent type error on string specific functions

Package community-engineering/language-nl_nl nl_NL.csv contains the following row:
`1,één`
Magento framework translate returns this as an integer
