### PR TITLE
Pass explicit $escape argument to fgetcsv/fputcsv for PHP 8.4 compatibility

### DIFF
--- a/Module/I18n/Dictionary/Loader/File/Csv.php
+++ b/Module/I18n/Dictionary/Loader/File/Csv.php
@@ -20,6 +20,6 @@ class Csv extends AbstractFile
      */
     protected function _readFile()
     {
-        return fgetcsv($this->_fileHandler, null, ',', '"');
+        return fgetcsv($this->_fileHandler, null, ',', '"', '\\');
     }
 }

--- a/Module/I18n/Dictionary/Writer/Csv.php
+++ b/Module/I18n/Dictionary/Writer/Csv.php
@@ -49,7 +49,7 @@ class Csv implements WriterInterface
             $fields[] = $contextValue;
         }
 
-        fputcsv($this->_fileHandler, $fields);
+        fputcsv($this->_fileHandler, $fields, ',', '"', '\\');
     }
 
     /**


### PR DESCRIPTION
## Summary

On PHP 8.4, `fgetcsv()`/`fputcsv()` deprecate the implicit default `$escape`. 

Pass `'\\'` (the current default) explicitly in both the writer and loader. No behavior change ... just silences the deprecation.

## Reproduction

```
bin/magento experius_missingtranslations:collect --magento --locale cs_CZ

Deprecated Functionality: fputcsv(): the $escape parameter must be provided
as its default value will change in .../Dictionary/Writer/Csv.php on line 52
```
  
Btw, great module - it just saved me a lot of headache :-). Cheers 👍 