### PR TITLE
Adds compatibility with symfony/console v7.x

### DIFF
--- a/Console/Command/CollectMissingTranslationsCommand.php
+++ b/Console/Command/CollectMissingTranslationsCommand.php
@@ -69,7 +69,7 @@ class CollectMissingTranslationsCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $directory = $input->getArgument(self::INPUT_KEY_DIRECTORY);
         if ($input->getOption(self::INPUT_KEY_MAGENTO)) {

--- a/Console/Command/ExistingTranslationsToDatabase.php
+++ b/Console/Command/ExistingTranslationsToDatabase.php
@@ -58,7 +58,7 @@ class ExistingTranslationsToDatabase extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->state->setAreaCode('frontend');
 

--- a/Console/Command/MissingTranslationsToDatabase.php
+++ b/Console/Command/MissingTranslationsToDatabase.php
@@ -58,7 +58,7 @@ class MissingTranslationsToDatabase extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->state->setAreaCode('frontend');
 


### PR DESCRIPTION
Adds compatibility with `symfony/console` 7.x so we can use this module on Magento 2.4.9

Otherwise we get this error when executing `bin/magento`:

```
$ bin/magento cache:flush
PHP Fatal error:  Declaration of Experius\MissingTranslations\Console\Command\CollectMissingTranslationsCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in vendor/experius/module-missingtranslations/Console/Command/CollectMissingTranslationsCommand.php on line 72
```

The addition of the `int` return type is backwards compatible with older versions of `symfony/console`, through php's [covariance](https://www.php.net/manual/en/language.oop5.variance.php#:~:text=Covariance%20allows%20a%20child%27s%20method%20to%20return%20a%20more%20specific%20type%20than%20the%20return%20type%20of%20its%20parent%27s%20method.).
